### PR TITLE
Update and Delete Functionality for Skills

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@fontsource/roboto": "^5.0.8",
+        "@mui/icons-material": "^5.14.19",
         "@mui/material": "^5.14.18",
         "@reduxjs/toolkit": "^1.9.7",
         "react": "^18.2.0",
@@ -1947,6 +1948,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.14.19",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.14.19.tgz",
+      "integrity": "sha512-yjP8nluXxZGe3Y7pS+yxBV+hWZSsSBampCxkZwaw+1l+feL+rfP74vbEFbMrX/Kil9I/Y1tWfy5bs/eNvwNpWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@fontsource/roboto": "^5.0.8",
+    "@mui/icons-material": "^5.14.19",
     "@mui/material": "^5.14.18",
     "@reduxjs/toolkit": "^1.9.7",
     "react": "^18.2.0",

--- a/frontend/src/components/Skillitem.tsx
+++ b/frontend/src/components/Skillitem.tsx
@@ -1,14 +1,72 @@
-import { Grid, Typography } from '@mui/material';
-import React from 'react';
+import React, { useState } from 'react';
+import { Grid, Typography, Select, IconButton, MenuItem } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import SaveIcon from '@mui/icons-material/Save';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { useDispatch } from 'react-redux';
+import { updateSkill, deleteSkill } from '../redux/store';
 import { SkillItem } from '../types'
 
 const Skillitem: React.FC<SkillItem> = ({ skill, level }) => {
+  const dispatch = useDispatch();
+
+  // local state to keep track of editing mode and edited level value
+  const [isEditing, setIsEditing] = useState(false);
+  const [editedLevel, setEditedLevel] = useState(level);
+
+  // toggle editing mode
+  const handleEditToggle = () => {
+    setIsEditing(!isEditing);
+  };
+
+  const handleSaveSkill = () => {
+    // dispatch the updateSkill action with the edited skill details
+    dispatch(updateSkill({ skill, level: editedLevel }));
+    // exit edit mode
+    setIsEditing(false);
+  };
+
+  const handleDeleteSkill = () => {
+    // dispatch the deleteSkill action with the skill name to delete
+    dispatch(deleteSkill(skill));
+  };
+
   return (
     <>
-      <Grid item xs={6} sm={3}>
-        <Typography variant="button">
-          {skill}: {level}
-        </Typography>
+      <Grid item xs={12} sm={12} alignItems="center">
+        {isEditing ? (
+          <>
+            <Typography variant="button">
+              {skill}
+            </Typography>
+            <Select
+              value={editedLevel}
+              onChange={(e) => setEditedLevel(e.target.value as 'Junior' | 'Mid' | 'Senior')}
+              label="Level"
+              variant="outlined"
+              size="small"
+            >
+              <MenuItem value="Junior">Junior</MenuItem>
+              <MenuItem value="Mid">Mid</MenuItem>
+              <MenuItem value="Senior">Senior</MenuItem>
+            </Select>
+            <IconButton aria-label="save" onClick={handleSaveSkill}>
+              <SaveIcon />
+            </IconButton>
+          </>
+        ) : (
+          <>
+            <Typography variant="button">
+              {skill}: {level}
+            </Typography>
+            <IconButton aria-label="edit" onClick={handleEditToggle}>
+              <EditIcon />
+            </IconButton>
+            <IconButton aria-label="Delete" onClick={handleDeleteSkill}>
+              <DeleteIcon />
+            </IconButton>
+          </>
+        )}
       </Grid>
     </>
   );

--- a/frontend/src/redux/store.ts
+++ b/frontend/src/redux/store.ts
@@ -23,11 +23,25 @@ const appSlice = createSlice({
     addSkill: (state, action: PayloadAction<SkillItem>) => {
       state.skills = [...state.skills, action.payload];
     },
+    updateSkill: (state, action: PayloadAction<SkillItem>) => {
+      // create copy of skills state
+      const skillsCopy: SkillItem[] = [...state.skills];
+      // find index where skill should be updated
+      const index: number = skillsCopy.findIndex(skill => skill.skill === action.payload.skill);
+      // update skill
+      skillsCopy[index] = {...action.payload};
+      // reassign skills state to updated copy
+      state.skills = skillsCopy;
+    },
+    deleteSkill: (state, action: PayloadAction<string>) => {
+      // filter out skill that matches payload
+      state.skills = [...state.skills].filter(skill => skill.skill !== action.payload)
+    },
   },
 });
 
 // extract reducer functions from the slice
-export const { setJobs, setSkills, addSkill } = appSlice.actions;
+export const { setJobs, setSkills, addSkill, updateSkill, deleteSkill } = appSlice.actions;
 
 // configure the Redux store using configureStore
 export const store = configureStore({


### PR DESCRIPTION
## Request Type
<!-- Select one of the following types that best describes this pull request: -->
- [X] New Feature
- [ ] Bug Fix
- [ ] Performance Improvement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (Specify): ____________________

## Description
Update and delete functionality has been added for skills. Users can now update the level associated with a skill, as well as delete individual skills.

## Issue
Update and delete functionality for skills was not previously implemented.

## Changes Made
updateSkill and deleteSkill reducers added to store.ts file; update and delete buttons added to Skillitem.tsx.

## Screenshots or GIFs (if applicable)
N/A.

## Testing
New skills added on frontend using "Add Skill" button. Skills were updated using the edit icon, and changes were reflected on frontend after saving. Skills were deleted using the delete icon, and changes were reflected on the frontend.

## Additional Notes
N/A.